### PR TITLE
v2.2.0

### DIFF
--- a/tests/concurrent_insert_test.php
+++ b/tests/concurrent_insert_test.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Concurrent Insert Test
+ *
+ * Bu script iki farklı kullanıcının aynı anda insert yapması durumunu simüle eder.
+ *
+ * Kullanım:
+ *   /Applications/MAMP/bin/php/php8.2.0/bin/php tests/concurrent_insert_test.php
+ *
+ * Beklenen: 200 kayıt (2 process x 100 insert)
+ * Race condition varsa: < 200 kayıt (kayıp veriler)
+ */
+
+require_once __DIR__ . '/../noneDB.php';
+
+// PHP executable path - bunu kendi sistemine göre ayarla
+$phpPath = '/Applications/MAMP/bin/php/php8.2.0/bin/php';
+
+// Ayarlar
+$testDbName = 'concurrent_test_' . time();
+$insertsPerProcess = 100;
+$processCount = 2;
+
+// Renk kodları
+function green($text) { return "\033[32m{$text}\033[0m"; }
+function red($text) { return "\033[31m{$text}\033[0m"; }
+function yellow($text) { return "\033[33m{$text}\033[0m"; }
+function blue($text) { return "\033[34m{$text}\033[0m"; }
+
+echo blue("╔══════════════════════════════════════════════════════════════╗\n");
+echo blue("║         noneDB Concurrent Insert Test                        ║\n");
+echo blue("╚══════════════════════════════════════════════════════════════╝\n\n");
+
+// Worker script - child process olarak çalışacak
+$workerScript = <<<'PHP'
+<?php
+require_once __DIR__ . '/../noneDB.php';
+
+$dbName = $argv[1];
+$workerId = $argv[2];
+$insertCount = (int)$argv[3];
+
+$db = new noneDB();
+$inserted = 0;
+
+for ($i = 0; $i < $insertCount; $i++) {
+    $result = $db->insert($dbName, [
+        'worker_id' => $workerId,
+        'sequence' => $i,
+        'timestamp' => microtime(true),
+        'data' => "Record {$i} from worker {$workerId}"
+    ]);
+
+    if (isset($result['n']) && $result['n'] > 0) {
+        $inserted++;
+    }
+
+    // Küçük bir rastgele gecikme - race condition şansını artırır
+    usleep(rand(0, 1000));
+}
+
+echo json_encode(['worker_id' => $workerId, 'inserted' => $inserted]);
+PHP;
+
+$workerFile = __DIR__ . '/concurrent_worker.php';
+file_put_contents($workerFile, $workerScript);
+
+// Temiz başlangıç
+$db = new noneDB();
+
+echo "Test Parametreleri:\n";
+echo "  • Database: {$testDbName}\n";
+echo "  • Process sayısı: {$processCount}\n";
+echo "  • Her process'in insert sayısı: {$insertsPerProcess}\n";
+echo "  • Beklenen toplam kayıt: " . ($processCount * $insertsPerProcess) . "\n\n";
+
+echo yellow("▶ Process'ler başlatılıyor...\n\n");
+
+// Parallel process'leri başlat
+$processes = [];
+$pipes = [];
+
+for ($i = 0; $i < $processCount; $i++) {
+    $workerId = "worker_{$i}";
+
+    $descriptorspec = [
+        0 => ["pipe", "r"],
+        1 => ["pipe", "w"],
+        2 => ["pipe", "w"]
+    ];
+
+    $cmd = "{$phpPath} {$workerFile} {$testDbName} {$workerId} {$insertsPerProcess}";
+    $process = proc_open($cmd, $descriptorspec, $p);
+
+    if (is_resource($process)) {
+        $processes[$workerId] = $process;
+        $pipes[$workerId] = $p;
+        echo "  ✓ {$workerId} başlatıldı\n";
+    }
+}
+
+echo "\n" . yellow("▶ Process'ler tamamlanması bekleniyor...\n\n");
+
+// Sonuçları topla
+$results = [];
+foreach ($processes as $workerId => $process) {
+    $output = stream_get_contents($pipes[$workerId][1]);
+    $errors = stream_get_contents($pipes[$workerId][2]);
+
+    fclose($pipes[$workerId][0]);
+    fclose($pipes[$workerId][1]);
+    fclose($pipes[$workerId][2]);
+
+    $exitCode = proc_close($process);
+
+    if ($output) {
+        $result = json_decode($output, true);
+        if ($result) {
+            $results[$workerId] = $result;
+            echo "  ✓ {$workerId}: {$result['inserted']} kayıt eklendi (rapor edilen)\n";
+        }
+    }
+
+    if ($errors) {
+        echo red("  ✗ {$workerId} hata: {$errors}\n");
+    }
+}
+
+// Gerçek kayıt sayısını kontrol et
+echo "\n" . yellow("▶ Veritabanı doğrulanıyor...\n\n");
+
+$allRecords = $db->find($testDbName, []);
+$actualCount = is_array($allRecords) ? count($allRecords) : 0;
+$expectedCount = $processCount * $insertsPerProcess;
+
+// Worker bazlı analiz
+$workerCounts = [];
+if (is_array($allRecords)) {
+    foreach ($allRecords as $record) {
+        if (isset($record['worker_id'])) {
+            $wid = $record['worker_id'];
+            $workerCounts[$wid] = ($workerCounts[$wid] ?? 0) + 1;
+        }
+    }
+}
+
+echo "Worker Bazlı Sonuçlar:\n";
+foreach ($workerCounts as $wid => $count) {
+    $status = $count === $insertsPerProcess ? green("✓") : red("✗");
+    echo "  {$status} {$wid}: {$count}/{$insertsPerProcess} kayıt\n";
+}
+
+echo "\n";
+echo "═══════════════════════════════════════════════════════════════\n";
+echo "SONUÇ:\n";
+echo "  • Beklenen kayıt sayısı: {$expectedCount}\n";
+echo "  • Gerçek kayıt sayısı:   {$actualCount}\n";
+
+if ($actualCount === $expectedCount) {
+    echo "\n" . green("  ✓ BAŞARILI: Tüm kayıtlar doğru şekilde eklendi!\n");
+    echo green("    Race condition tespit edilmedi.\n");
+} else {
+    $lost = $expectedCount - $actualCount;
+    echo "\n" . red("  ✗ BAŞARISIZ: {$lost} kayıt kayboldu!\n");
+    echo red("    Race condition tespit edildi!\n");
+    echo "\n";
+    echo yellow("  Çözüm önerileri:\n");
+    echo "  1. Atomik dosya kilitleme (flock ile read-modify-write)\n";
+    echo "  2. Veritabanı seviyesinde mutex\n";
+    echo "  3. Optimistik kilitleme (version numarası ile)\n";
+}
+echo "═══════════════════════════════════════════════════════════════\n";
+
+// Temizlik
+unlink($workerFile);
+
+// Test veritabanı dosyalarını temizle
+$dbDir = __DIR__ . '/../db/';
+$files = glob($dbDir . '*' . $testDbName . '*');
+foreach ($files as $file) {
+    unlink($file);
+}
+
+echo "\n" . blue("Test tamamlandı. Test veritabanı silindi.\n");

--- a/tests/concurrent_stress_test.php
+++ b/tests/concurrent_stress_test.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Concurrent Stress Test - Daha agresif test
+ *
+ * 5 process x 50 insert = 250 kayıt
+ */
+
+require_once __DIR__ . '/../noneDB.php';
+
+$phpPath = '/Applications/MAMP/bin/php/php8.2.0/bin/php';
+$testDbName = 'stress_test_' . time();
+$insertsPerProcess = 50;
+$processCount = 5;
+
+function green($text) { return "\033[32m{$text}\033[0m"; }
+function red($text) { return "\033[31m{$text}\033[0m"; }
+function yellow($text) { return "\033[33m{$text}\033[0m"; }
+
+echo "╔════════════════════════════════════════════════════════════╗\n";
+echo "║      noneDB Concurrent STRESS Test (5 Process)             ║\n";
+echo "╚════════════════════════════════════════════════════════════╝\n\n";
+
+// Worker script - NO delay version for maximum stress
+$workerScript = <<<'PHP'
+<?php
+require_once __DIR__ . '/../noneDB.php';
+$db = new noneDB();
+$inserted = 0;
+for ($i = 0; $i < (int)$argv[3]; $i++) {
+    $result = $db->insert($argv[1], [
+        'worker_id' => $argv[2],
+        'seq' => $i,
+        'ts' => microtime(true)
+    ]);
+    if (isset($result['n']) && $result['n'] > 0) $inserted++;
+}
+echo json_encode(['w' => $argv[2], 'n' => $inserted]);
+PHP;
+
+$workerFile = __DIR__ . '/stress_worker.php';
+file_put_contents($workerFile, $workerScript);
+
+$db = new noneDB();
+$expectedCount = $processCount * $insertsPerProcess;
+
+echo "Config: {$processCount} process x {$insertsPerProcess} insert = {$expectedCount} kayıt bekleniyor\n\n";
+
+// Start all processes
+$processes = [];
+$pipes = [];
+for ($i = 0; $i < $processCount; $i++) {
+    $cmd = "{$phpPath} {$workerFile} {$testDbName} w{$i} {$insertsPerProcess}";
+    $process = proc_open($cmd, [0=>["pipe","r"], 1=>["pipe","w"], 2=>["pipe","w"]], $p);
+    if (is_resource($process)) {
+        $processes["w{$i}"] = $process;
+        $pipes["w{$i}"] = $p;
+    }
+}
+
+// Collect results
+$totalReported = 0;
+foreach ($processes as $wid => $process) {
+    $output = stream_get_contents($pipes[$wid][1]);
+    fclose($pipes[$wid][0]);
+    fclose($pipes[$wid][1]);
+    fclose($pipes[$wid][2]);
+    proc_close($process);
+
+    if ($output) {
+        $r = json_decode($output, true);
+        if ($r) {
+            $totalReported += $r['n'];
+            echo "  {$wid}: {$r['n']} kayıt (rapor)\n";
+        }
+    }
+}
+
+// Verify
+$allRecords = $db->find($testDbName, []);
+$actualCount = is_array($allRecords) ? count($allRecords) : 0;
+
+// Worker breakdown
+$workerCounts = [];
+if (is_array($allRecords)) {
+    foreach ($allRecords as $rec) {
+        if (isset($rec['worker_id'])) {
+            $workerCounts[$rec['worker_id']] = ($workerCounts[$rec['worker_id']] ?? 0) + 1;
+        }
+    }
+}
+
+echo "\n═══════════════════════════════════════════════════════════════\n";
+echo "SONUÇ:\n";
+echo "  • Worker'ların rapor ettiği: {$totalReported}\n";
+echo "  • Beklenen:                  {$expectedCount}\n";
+echo "  • Gerçek:                    {$actualCount}\n";
+
+if ($actualCount === $expectedCount) {
+    echo "\n" . green("  ✓ BAŞARILI - Veri kaybı yok!\n");
+} else {
+    $lost = $expectedCount - $actualCount;
+    $lostPct = round(($lost / $expectedCount) * 100, 1);
+    echo "\n" . red("  ✗ BAŞARISIZ - {$lost} kayıt kayboldu (%{$lostPct})\n");
+
+    echo "\nWorker bazlı kayıp:\n";
+    for ($i = 0; $i < $processCount; $i++) {
+        $wid = "w{$i}";
+        $actual = $workerCounts[$wid] ?? 0;
+        $lost = $insertsPerProcess - $actual;
+        if ($lost > 0) {
+            echo red("  {$wid}: {$actual}/{$insertsPerProcess} ({$lost} kayıp)\n");
+        } else {
+            echo green("  {$wid}: {$actual}/{$insertsPerProcess} (tamam)\n");
+        }
+    }
+}
+echo "═══════════════════════════════════════════════════════════════\n";
+
+// Cleanup
+unlink($workerFile);
+$files = glob(__DIR__ . '/../db/*' . $testDbName . '*');
+foreach ($files as $f) unlink($f);

--- a/tests/performance_benchmark.php
+++ b/tests/performance_benchmark.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * noneDB Performance Benchmark
+ * Tests all operations from 100 to 500K records
+ */
+
+require_once __DIR__ . '/../noneDB.php';
+
+ini_set('memory_limit', '-1');
+set_time_limit(0);
+
+$db = new noneDB();
+
+// Test sizes
+$sizes = [100, 1000, 10000, 50000, 100000, 500000];
+
+// Colors
+function green($t) { return "\033[32m{$t}\033[0m"; }
+function yellow($t) { return "\033[33m{$t}\033[0m"; }
+function blue($t) { return "\033[34m{$t}\033[0m"; }
+function cyan($t) { return "\033[36m{$t}\033[0m"; }
+
+// Format time
+function formatTime($ms) {
+    if ($ms < 1) return "<1 ms";
+    if ($ms >= 1000) return round($ms / 1000, 1) . " s";
+    return round($ms) . " ms";
+}
+
+// Generate test record
+function generateRecord($i) {
+    $cities = ['Istanbul', 'Ankara', 'Izmir', 'Bursa', 'Antalya'];
+    $depts = ['IT', 'HR', 'Sales', 'Marketing', 'Finance'];
+    return [
+        "name" => "User" . $i,
+        "email" => "user{$i}@test.com",
+        "age" => 20 + ($i % 50),
+        "salary" => 5000 + ($i % 10000),
+        "city" => $cities[$i % 5],
+        "department" => $depts[$i % 5],
+        "active" => ($i % 3 !== 0)
+    ];
+}
+
+echo blue("╔════════════════════════════════════════════════════════════════════╗\n");
+echo blue("║              noneDB Performance Benchmark v2.2                     ║\n");
+echo blue("║         Atomic File Locking - Thread-Safe Operations               ║\n");
+echo blue("╚════════════════════════════════════════════════════════════════════╝\n\n");
+
+echo "PHP Version: " . PHP_VERSION . "\n";
+echo "OS: " . PHP_OS . "\n\n";
+
+$results = [
+    'write' => ['insert' => [], 'update' => [], 'delete' => []],
+    'read' => ['find_all' => [], 'find_key' => [], 'find_filter' => []],
+    'query' => ['count' => [], 'distinct' => [], 'sum' => [], 'like' => [], 'between' => [], 'sort' => [], 'first' => [], 'exists' => []],
+    'chain' => ['whereIn' => [], 'orWhere' => [], 'search' => [], 'groupBy' => [], 'select' => [], 'complex' => []]
+];
+
+foreach ($sizes as $size) {
+    $dbName = "perftest_" . $size;
+
+    echo yellow("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+    echo yellow("  Testing with " . number_format($size) . " records\n");
+    echo yellow("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+    // Clean up
+    $files = glob(__DIR__ . '/../db/*' . $dbName . '*');
+    foreach ($files as $f) @unlink($f);
+
+    // ===== WRITE OPERATIONS =====
+    echo "\n" . cyan("  Write Operations:\n");
+
+    // INSERT
+    $data = [];
+    for ($i = 0; $i < $size; $i++) {
+        $data[] = generateRecord($i);
+    }
+
+    $start = microtime(true);
+    $db->insert($dbName, $data);
+    $insertTime = (microtime(true) - $start) * 1000;
+    $results['write']['insert'][$size] = $insertTime;
+    echo "    insert():     " . green(formatTime($insertTime)) . "\n";
+
+    // UPDATE
+    $start = microtime(true);
+    $db->update($dbName, [
+        ['city' => 'Istanbul'],
+        ['set' => ['region' => 'Marmara']]
+    ]);
+    $updateTime = (microtime(true) - $start) * 1000;
+    $results['write']['update'][$size] = $updateTime;
+    echo "    update():     " . green(formatTime($updateTime)) . "\n";
+
+    // DELETE (small portion)
+    $start = microtime(true);
+    $db->delete($dbName, ['department' => 'HR']);
+    $deleteTime = (microtime(true) - $start) * 1000;
+    $results['write']['delete'][$size] = $deleteTime;
+    echo "    delete():     " . green(formatTime($deleteTime)) . "\n";
+
+    // Re-insert for read tests
+    $files = glob(__DIR__ . '/../db/*' . $dbName . '*');
+    foreach ($files as $f) @unlink($f);
+    $db->insert($dbName, $data);
+
+    // ===== READ OPERATIONS =====
+    echo "\n" . cyan("  Read Operations:\n");
+
+    // FIND ALL
+    $start = microtime(true);
+    $db->find($dbName, []);
+    $findAllTime = (microtime(true) - $start) * 1000;
+    $results['read']['find_all'][$size] = $findAllTime;
+    echo "    find(all):    " . green(formatTime($findAllTime)) . "\n";
+
+    // FIND BY KEY
+    $testKey = (int)($size / 2);
+    $start = microtime(true);
+    $db->find($dbName, ['key' => $testKey]);
+    $findKeyTime = (microtime(true) - $start) * 1000;
+    $results['read']['find_key'][$size] = $findKeyTime;
+    echo "    find(key):    " . green(formatTime($findKeyTime)) . "\n";
+
+    // FIND WITH FILTER
+    $start = microtime(true);
+    $db->find($dbName, ['city' => 'Ankara']);
+    $findFilterTime = (microtime(true) - $start) * 1000;
+    $results['read']['find_filter'][$size] = $findFilterTime;
+    echo "    find(filter): " . green(formatTime($findFilterTime)) . "\n";
+
+    // ===== QUERY & AGGREGATION =====
+    echo "\n" . cyan("  Query & Aggregation:\n");
+
+    // COUNT
+    $start = microtime(true);
+    $db->count($dbName);
+    $countTime = (microtime(true) - $start) * 1000;
+    $results['query']['count'][$size] = $countTime;
+    echo "    count():      " . green(formatTime($countTime)) . "\n";
+
+    // DISTINCT
+    $start = microtime(true);
+    $db->distinct($dbName, 'city');
+    $distinctTime = (microtime(true) - $start) * 1000;
+    $results['query']['distinct'][$size] = $distinctTime;
+    echo "    distinct():   " . green(formatTime($distinctTime)) . "\n";
+
+    // SUM
+    $start = microtime(true);
+    $db->sum($dbName, 'salary');
+    $sumTime = (microtime(true) - $start) * 1000;
+    $results['query']['sum'][$size] = $sumTime;
+    echo "    sum():        " . green(formatTime($sumTime)) . "\n";
+
+    // LIKE
+    $start = microtime(true);
+    $db->query($dbName)->like('name', '^User1')->get();
+    $likeTime = (microtime(true) - $start) * 1000;
+    $results['query']['like'][$size] = $likeTime;
+    echo "    like():       " . green(formatTime($likeTime)) . "\n";
+
+    // BETWEEN
+    $start = microtime(true);
+    $db->query($dbName)->between('age', 25, 35)->get();
+    $betweenTime = (microtime(true) - $start) * 1000;
+    $results['query']['between'][$size] = $betweenTime;
+    echo "    between():    " . green(formatTime($betweenTime)) . "\n";
+
+    // SORT
+    $start = microtime(true);
+    $db->query($dbName)->sort('salary', 'desc')->limit(100)->get();
+    $sortTime = (microtime(true) - $start) * 1000;
+    $results['query']['sort'][$size] = $sortTime;
+    echo "    sort():       " . green(formatTime($sortTime)) . "\n";
+
+    // FIRST
+    $start = microtime(true);
+    $db->query($dbName)->where(['city' => 'Izmir'])->first();
+    $firstTime = (microtime(true) - $start) * 1000;
+    $results['query']['first'][$size] = $firstTime;
+    echo "    first():      " . green(formatTime($firstTime)) . "\n";
+
+    // EXISTS
+    $start = microtime(true);
+    $db->query($dbName)->where(['city' => 'Bursa'])->exists();
+    $existsTime = (microtime(true) - $start) * 1000;
+    $results['query']['exists'][$size] = $existsTime;
+    echo "    exists():     " . green(formatTime($existsTime)) . "\n";
+
+    // ===== METHOD CHAINING =====
+    echo "\n" . cyan("  Method Chaining:\n");
+
+    // WHEREIN
+    $start = microtime(true);
+    $db->query($dbName)->whereIn('city', ['Istanbul', 'Ankara'])->get();
+    $whereInTime = (microtime(true) - $start) * 1000;
+    $results['chain']['whereIn'][$size] = $whereInTime;
+    echo "    whereIn():    " . green(formatTime($whereInTime)) . "\n";
+
+    // ORWHERE
+    $start = microtime(true);
+    $db->query($dbName)->where(['city' => 'Istanbul'])->orWhere(['city' => 'Ankara'])->get();
+    $orWhereTime = (microtime(true) - $start) * 1000;
+    $results['chain']['orWhere'][$size] = $orWhereTime;
+    echo "    orWhere():    " . green(formatTime($orWhereTime)) . "\n";
+
+    // SEARCH
+    $start = microtime(true);
+    $db->query($dbName)->search('User1', ['name', 'email'])->get();
+    $searchTime = (microtime(true) - $start) * 1000;
+    $results['chain']['search'][$size] = $searchTime;
+    echo "    search():     " . green(formatTime($searchTime)) . "\n";
+
+    // GROUPBY
+    $start = microtime(true);
+    $db->query($dbName)->groupBy('department')->get();
+    $groupByTime = (microtime(true) - $start) * 1000;
+    $results['chain']['groupBy'][$size] = $groupByTime;
+    echo "    groupBy():    " . green(formatTime($groupByTime)) . "\n";
+
+    // SELECT
+    $start = microtime(true);
+    $db->query($dbName)->select(['name', 'email', 'city'])->get();
+    $selectTime = (microtime(true) - $start) * 1000;
+    $results['chain']['select'][$size] = $selectTime;
+    echo "    select():     " . green(formatTime($selectTime)) . "\n";
+
+    // COMPLEX CHAIN
+    $start = microtime(true);
+    $db->query($dbName)
+        ->where(['active' => true])
+        ->whereIn('city', ['Istanbul', 'Ankara'])
+        ->between('age', 25, 40)
+        ->select(['name', 'city', 'salary'])
+        ->sort('salary', 'desc')
+        ->limit(50)
+        ->get();
+    $complexTime = (microtime(true) - $start) * 1000;
+    $results['chain']['complex'][$size] = $complexTime;
+    echo "    complex:      " . green(formatTime($complexTime)) . "\n";
+
+    // Cleanup
+    $files = glob(__DIR__ . '/../db/*' . $dbName . '*');
+    foreach ($files as $f) @unlink($f);
+
+    echo "\n";
+}
+
+// ===== PRINT MARKDOWN TABLES =====
+echo blue("\n╔════════════════════════════════════════════════════════════════════╗\n");
+echo blue("║                    MARKDOWN TABLES FOR README                       ║\n");
+echo blue("╚════════════════════════════════════════════════════════════════════╝\n\n");
+
+function printTable($title, $data, $sizes) {
+    echo "### {$title}\n";
+    echo "| Operation |";
+    foreach ($sizes as $s) {
+        $label = $s >= 1000 ? ($s / 1000) . "K" : $s;
+        echo " {$label} |";
+    }
+    echo "\n|-----------|";
+    foreach ($sizes as $s) echo "-----|";
+    echo "\n";
+
+    foreach ($data as $op => $times) {
+        echo "| {$op} |";
+        foreach ($sizes as $s) {
+            $t = isset($times[$s]) ? formatTime($times[$s]) : "-";
+            echo " {$t} |";
+        }
+        echo "\n";
+    }
+    echo "\n";
+}
+
+printTable("Write Operations", $results['write'], $sizes);
+printTable("Read Operations", $results['read'], $sizes);
+printTable("Query & Aggregation", $results['query'], $sizes);
+printTable("Method Chaining (v2.1+)", $results['chain'], $sizes);
+
+echo green("\nBenchmark completed!\n");


### PR DESCRIPTION
## v2.2.0 (2025-12-27)

### Major: Atomic File Locking

This release implements **professional-grade atomic file locking** to ensure thread-safe concurrent access. No more lost updates or race conditions!

#### New Core Methods

Three new private methods handle all file operations atomically:

```php
// Atomic read with shared lock (LOCK_SH)
private function atomicRead($path, $default = null)

// Atomic write with exclusive lock (LOCK_EX)
private function atomicWrite($path, $data, $prettyPrint = false)

// Atomic read-modify-write in single locked operation
private function atomicModify($path, callable $modifier, $default = null)
```

#### How It Works

```
┌───────────────────────────────────────────────────────────┐
│  Before v2.2 (Race Condition)                             │
├───────────────────────────────────────────────────────────┤
│  Process A: read → modify → write                         │
│  Process B:    read → modify → write                      │
│  Result: Process A's changes LOST!                        │
└───────────────────────────────────────────────────────────┘

┌───────────────────────────────────────────────────────────┐
│  After v2.2 (Atomic Operations)                           │
├───────────────────────────────────────────────────────────┤
│  Process A: [LOCK → read → modify → write → UNLOCK]       │
│  Process B:        [wait...] [LOCK → read → modify → ...]│
│  Result: ALL changes preserved!                           │
└───────────────────────────────────────────────────────────┘
```

#### Test Results

| Scenario | Before v2.2 | After v2.2 |
|----------|-------------|------------|
| 2 processes × 100 inserts | 46-199 records (up to 77% loss) | **200/200** (0% loss) | | 5 processes × 50 inserts | 41 records (83.6% loss!) | **250/250** (0% loss) |

#### Updated Methods

All write operations now use atomic locking:
- `insert()`, `update()`, `delete()`
- `insertSharded()`, `updateSharded()`, `deleteSharded()`
- `readMeta()`, `writeMeta()`, `getShardData()`, `writeShardData()`

#### Configuration

New configuration options for fine-tuning:

```php
private $lockTimeout = 5;        // Max seconds to wait for lock
private $lockRetryDelay = 10000; // Microseconds between retry attempts
```

### Performance Benchmarks Updated

Added 500K record benchmarks. Key highlights:
- `find(key)` stays at **23ms** even at 500K records (thanks to sharding)
- Full table operations scale linearly (~3-5s for 500K records)

---